### PR TITLE
Fix Compiling latest VS Code Version 1.91 fails & other improvements

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,10 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           registry-url: https://registry.npmjs.org/
       - name: Setup Build Environment
         run: |

--- a/build.js
+++ b/build.js
@@ -44,7 +44,6 @@ if (!fs.existsSync("vscode")) {
   exec(`git clone --depth 1 https://github.com/microsoft/vscode.git -b ${VSCODE_VERSION}`, {
     stdio: "inherit",
   });
-  exec("cd vscode && git apply ../vscode.patch", { stdio: "inherit" });
 } else {
   ok("vscodium already installed")
   note("delete vscodium folder to clone again")

--- a/build.js
+++ b/build.js
@@ -34,8 +34,8 @@ ok("required tools installed")
 
 const node_version_out = child_process.execSync(`node -v`);
 const node_version = node_version_out.toString().trim()
-if (node_version < "v18.15" || node_version >= "v19.0") {
-  error(`Want node > 18.15 and < 19. Got "${node_version}"`);
+if (node_version < "v20.0") {
+  error(`Want node > 20. Got "${node_version}"`);
   process.exit(1);
 }
 

--- a/build.js
+++ b/build.js
@@ -1,10 +1,10 @@
-const fs = require("fs");
-const path = require("path");
-const assert = require("assert");
+const process = require("process");
 const child_process = require("child_process");
+const fs = require("fs");
+const fse = require("fs-extra");
 const { version } = require("./package.json");
 
-const VSCODE_VERSION = version.split("-")[0];
+const vscodeVersion = version.split("-")[0];
 
 function error(msg) {
   console.info("\x1b[31merror %s\x1b[0m", msg)
@@ -41,12 +41,12 @@ if (node_version < "v20.0") {
 
 if (!fs.existsSync("vscode")) {
   note("cloning vscode")
-  exec(`git clone --depth 1 https://github.com/microsoft/vscode.git -b ${VSCODE_VERSION}`, {
+  exec(`git clone --depth 1 https://github.com/microsoft/vscode.git -b ${vscodeVersion}`, {
     stdio: "inherit",
   });
 } else {
-  ok("vscodium already installed")
-  note("delete vscodium folder to clone again")
+  ok("vscode already installed")
+  note("delete vscode folder to clone again")
 }
 
 note("changing directory to vscode")
@@ -70,56 +70,11 @@ ok("compile completed")
 // Extract compiled files
 if (fs.existsSync("../dist")) {
   note("cleaning ../dist")
-  fs.rmSync("../dist", { recursive: true, force: true });
+  fs.rmdirSync("../dist", { recursive: true });
 } else {
   ok("../dist did not exist. No need to clean")
 }
 
 fs.mkdirSync("../dist");
-fs.cpSync("../vscode-web", "../dist", { recursive: true, force: true });
+fse.copySync("../vscode-web", "../dist");
 ok("copied ../vscode-web to ../dist")
-
-// Patch output
-note("beginning complex patches for networking")
-const distWorkbenchPath = "../dist/out/vs/workbench/workbench.web.main.js";
-const workbench = fs.readFileSync(distWorkbenchPath, "utf8");
-const workbenchPatched = workbench.replace(/("https:\/\/{{uuid}}[^"]+")/g, "(globalThis.VSCODE_WEB_PUBLIC_URL||$1)");
-fs.writeFileSync(distWorkbenchPath, workbenchPatched, "utf8");
-
-// Strip sourcemaps and patch vscode-uri for "://" URIs
-const re = /.=function\(\)\{function .\((.),.,(.),.,(.),.\)\{/g;
-const patchOutput = async (destPath) => {
-  let hasPatched = false;
-  let hasStripped = false;
-  const stat = await fs.promises.stat(destPath);
-  if (stat.isDirectory()) {
-    for (const child of await fs.promises.readdir(destPath)) {
-      hasStripped |= await patchOutput(path.join(destPath, child));
-    }
-  }
-  if (stat.isFile() && destPath.endsWith(".js")) {
-    const content = await fs.promises.readFile(destPath, "utf8");
-    const stripped = content.replace(/^\/\/# sourceMappingURL=[^\r\n]*/gm, "");
-    if (stripped !== content) {
-      note(`Stripped sourcemaps from ${destPath}`);
-      await fs.promises.writeFile(destPath, stripped, "utf8");
-      hasStripped = true;
-    }
-    if (destPath.includes("jsonServer")) {
-      const matches = re.exec(stripped);
-      if (matches && matches.length === 4) {
-        const [_, e, n, t] = matches;
-        const patched = stripped.replace(
-          re,
-          `${_}if(${n}&&${n}.startsWith("://")){try{let o=globalThis.origin.split("://");${e}=o[0];${t}=o[1];${n}=${n}.replace("://","/")}catch(_){}};`
-        );
-        ok(`Patched ${destPath} for vscode-uri`);
-        await fs.promises.writeFile(destPath, patched, "utf8");
-        hasPatched = true;
-      }
-    }
-  }
-  return hasStripped && hasPatched;
-};
-
-assert(patchOutput(path.join(__dirname, "dist")), "Failed to patch output.");

--- a/build.js
+++ b/build.js
@@ -1,34 +1,126 @@
-const process = require("process");
-const child_process = require("child_process");
 const fs = require("fs");
-const fse = require("fs-extra");
+const path = require("path");
+const assert = require("assert");
+const child_process = require("child_process");
+const { version } = require("./package.json");
 
-const vscodeVersion = "1.84.2";
+const VSCODE_VERSION = version.split("-")[0];
+
+function error(msg) {
+  console.info("\x1b[31merror %s\x1b[0m", msg)
+}
+function ok(msg) {
+  console.info("\x1b[32m%s\x1b[0m", msg)
+}
+function note(msg) {
+  console.info("\x1b[90m%s\x1b[0m", msg)
+}
+function exec(cmd, opts) {
+  console.info("\x1b[36m%s\x1b[0m", cmd)
+  return child_process.execSync(cmd, opts);
+}
+
+const requiredTools = ["node", "yarn", "git", "python"];
+note(`required tools ${JSON.stringify(requiredTools)}`)
+for (const tool of requiredTools) {
+  try {
+    child_process.execSync(`${tool} --version`, { stdio: "ignore" });
+  } catch (e) {
+    error(`"${tool}" is not available.`);
+    process.exit(1);
+  }
+}
+ok("required tools installed")
+
+const node_version_out = child_process.execSync(`node -v`);
+const node_version = node_version_out.toString().trim()
+if (node_version < "v18.15" || node_version >= "v19.0") {
+  error(`Want node > 18.15 and < 19. Got "${node_version}"`);
+  process.exit(1);
+}
 
 if (!fs.existsSync("vscode")) {
-  child_process.execSync(`git clone --depth 1 https://github.com/microsoft/vscode.git -b ${vscodeVersion}`, {
+  note("cloning vscode")
+  exec(`git clone --depth 1 https://github.com/microsoft/vscode.git -b ${VSCODE_VERSION}`, {
     stdio: "inherit",
   });
+  exec("cd vscode && git apply ../vscode.patch", { stdio: "inherit" });
+} else {
+  ok("vscodium already installed")
+  note("delete vscodium folder to clone again")
 }
+
+note("changing directory to vscode")
 process.chdir("vscode");
 
 if (!fs.existsSync("node_modules")) {
-  child_process.execSync("yarn", { stdio: "inherit" });
+  exec("yarn", { stdio: "inherit" });
+} else {
+  ok("node_modules exists. Skipping yarn")
 }
+
 // Use simple workbench
-fs.copyFileSync(
-  "../workbench.ts",
-  "src/vs/code/browser/workbench/workbench.ts"
-);
+note("copying workbench file")
+fs.copyFileSync("../workbench.ts", "src/vs/code/browser/workbench/workbench.ts");
 
 // Compile
-child_process.execSync("yarn gulp vscode-web-min", { stdio: "inherit" });
+note("starting compile")
+exec("yarn gulp vscode-web-min", { stdio: "inherit" });
+ok("compile completed")
 
 // Extract compiled files
 if (fs.existsSync("../dist")) {
-  fs.rmdirSync("../dist", { recursive: true });
+  note("cleaning ../dist")
+  fs.rmSync("../dist", { recursive: true, force: true });
+} else {
+  ok("../dist did not exist. No need to clean")
 }
+
 fs.mkdirSync("../dist");
-fse.copySync("../vscode-web", "../dist");
+fs.cpSync("../vscode-web", "../dist", { recursive: true, force: true });
+ok("copied ../vscode-web to ../dist")
 
+// Patch output
+note("beginning complex patches for networking")
+const distWorkbenchPath = "../dist/out/vs/workbench/workbench.web.main.js";
+const workbench = fs.readFileSync(distWorkbenchPath, "utf8");
+const workbenchPatched = workbench.replace(/("https:\/\/{{uuid}}[^"]+")/g, "(globalThis.VSCODE_WEB_PUBLIC_URL||$1)");
+fs.writeFileSync(distWorkbenchPath, workbenchPatched, "utf8");
 
+// Strip sourcemaps and patch vscode-uri for "://" URIs
+const re = /.=function\(\)\{function .\((.),.,(.),.,(.),.\)\{/g;
+const patchOutput = async (destPath) => {
+  let hasPatched = false;
+  let hasStripped = false;
+  const stat = await fs.promises.stat(destPath);
+  if (stat.isDirectory()) {
+    for (const child of await fs.promises.readdir(destPath)) {
+      hasStripped |= await patchOutput(path.join(destPath, child));
+    }
+  }
+  if (stat.isFile() && destPath.endsWith(".js")) {
+    const content = await fs.promises.readFile(destPath, "utf8");
+    const stripped = content.replace(/^\/\/# sourceMappingURL=[^\r\n]*/gm, "");
+    if (stripped !== content) {
+      note(`Stripped sourcemaps from ${destPath}`);
+      await fs.promises.writeFile(destPath, stripped, "utf8");
+      hasStripped = true;
+    }
+    if (destPath.includes("jsonServer")) {
+      const matches = re.exec(stripped);
+      if (matches && matches.length === 4) {
+        const [_, e, n, t] = matches;
+        const patched = stripped.replace(
+          re,
+          `${_}if(${n}&&${n}.startsWith("://")){try{let o=globalThis.origin.split("://");${e}=o[0];${t}=o[1];${n}=${n}.replace("://","/")}catch(_){}};`
+        );
+        ok(`Patched ${destPath} for vscode-uri`);
+        await fs.promises.writeFile(destPath, patched, "utf8");
+        hasPatched = true;
+      }
+    }
+  }
+  return hasStripped && hasPatched;
+};
+
+assert(patchOutput(path.join(__dirname, "dist")), "Failed to patch output.");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-web",
-  "version": "1.84.2",
+  "version": "1.91.1",
   "description": "Visual Studio Code for browser",
   "files": ["dist"],
   "scripts": {

--- a/workbench.ts
+++ b/workbench.ts
@@ -16,7 +16,7 @@ declare const window: any;
   if (window.product) {
     config = window.product;
   } else {
-    const result = await fetch("/product.json");
+    const result = await fetch("product.json");
     config = await result.json();
   }
 

--- a/workbench.ts
+++ b/workbench.ts
@@ -2,8 +2,7 @@ import {
   create
 } from "vs/workbench/workbench.web.main";
 import { URI, UriComponents } from "vs/base/common/uri";
-import { IWorkbenchConstructionOptions } from "vs/workbench/browser/web.api";
-import { IWorkspace, IWorkspaceProvider } from "vs/workbench/services/host/browser/browserHostService";
+import { IWorkbenchConstructionOptions, IWorkspace, IWorkspaceProvider } from "vs/workbench/browser/web.api";
 declare const window: any;
 
 (async function () {


### PR DESCRIPTION
As mentioned in issue https://github.com/Felx-B/vscode-web/issues/37

This PR includes a fix of workbench.ts that would allow to compile for newer versions as well as enhancemets of build.js.

Also i bumped up the node version and action versions in the workflow ( --> newer vscode requires node 20)

also i did a little change in workbench.ts to make the loading of product.json relative from where the vscode web dist is served.
`fetch("product.json");`

Critics and comments welcome!

Would be cool to have your repo supporting the newest 1.91 vscode version!